### PR TITLE
Change border attribute to inner_padding

### DIFF
--- a/trim_atlas.py
+++ b/trim_atlas.py
@@ -21,7 +21,7 @@ ELEMENT_IMAGES = 'images'
 ATTR_IMAGE = 'image'
 ATTR_PIVOT_X = 'pivot_x'
 ATTR_PIVOT_Y = 'pivot_y'
-ATTR_BORDERS = 'extrude_borders'
+ATTR_BORDERS = 'inner_padding'
 EXT_BAK = '.bak'
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Changed border attribute to inner_padding, because extrude_borders does not influence pivot, but inner_padding does. With the old version, when using extrude_borders in an atlas, the pivot will be wrong by the size of the border.